### PR TITLE
Add redux to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "devDependencies": {
     "enzyme": "^2.4.1",
-    "react-scripts": "0.2.1"
+    "react-redux": "^4.4.5",
+    "react-scripts": "0.2.1",
+    "redux": "^3.6.0"
   },
   "dependencies": {
     "react": "^15.2.1",


### PR DESCRIPTION
When I removed and re-ran `npm install`, I noticed that `redux` and `react-redux` weren't installing. I must have initially installed them without `--save-dev`. 
