### PR TITLE
Fix `Too Short` Error

### DIFF
--- a/src/reducers/__test__/check-easy-equations.test.js
+++ b/src/reducers/__test__/check-easy-equations.test.js
@@ -3,11 +3,12 @@ import T from 'i18n-react'
 import Texts from '../../texts.js'
 
 it('checks for easy equations', () => {
-  expect(checkEasyEquation([22, "="], [true, false])).toEqual(T.texts.feedback.tooShort),
-  expect(checkEasyEquation([22, "*", 2, "="], [true, false])).toEqual(""),
-  expect(checkEasyEquation([22, "*", 0], [true, false, true])).toEqual(T.texts.feedback.zero),
+  expect(checkEasyEquation([2, 2, "="], [true, true, false])).toEqual(T.texts.feedback.tooShort),
+  expect(checkEasyEquation([2, 2, "*", 2, "="], [true, true, false])).toEqual(""),
+  expect(checkEasyEquation([2, 2, "*", 0], [true, true, false, true])).toEqual(T.texts.feedback.zero),
   expect(checkEasyEquation([0, "/"], [true, false])).toEqual(T.texts.feedback.zero),
-  expect(checkEasyEquation([22, "^", 2, "="], [true, false, true, false])).toEqual(""),
-  expect(checkEasyEquation([4, "+", 0, "*", 300], [true, false, true, false, true])).toEqual(T.texts.feedback.zero),
+  expect(checkEasyEquation([2, 2, "^", 2, "="], [true, true, false, true, false])).toEqual(""),
+  expect(checkEasyEquation([4, "+", 0, "*", 300], [true, false, true, false, true, true, true])).toEqual(T.texts.feedback.zero),
   expect(checkEasyEquation([0], [true])).toEqual(T.texts.feedback.zero)
+  expect(checkEasyEquation([5, 6, 5, "*", 3, "="], [true, true, true, false, true, false])).toEqual("")
 })

--- a/src/reducers/__test__/reducer-game-data.test.js
+++ b/src/reducers/__test__/reducer-game-data.test.js
@@ -147,6 +147,18 @@ let tests = [
       feedback: T.texts.feedback.tooShort
     }
   },
+  {
+    gameData: {
+      equation: [3 ,3, 5, "*", 2]
+    },
+    action: {
+      type: 'CLICK_CALCULATOR',
+      itemClicked: "="
+    },
+    expectedGameData: {
+      equation: [3 ,3, 5, "*", 2, "="]
+    }
+  },
   // Complete and pending equations
   {
     gameData: {

--- a/src/reducers/check-easy-equations.js
+++ b/src/reducers/check-easy-equations.js
@@ -1,15 +1,15 @@
 import T from 'i18n-react'
 
-const checkEasyEquations = (equationWithNumbers, isIntArray) => {
+const checkEasyEquations = (equation, isIntArray) => {
 
-  for (var i = 0; i < equationWithNumbers.length; i++) {
-    if(equationWithNumbers[i] === 0){
-      if(equationWithNumbers.indexOf("=") === -1 || equationWithNumbers.indexOf("=") > i)
+  for (var i = 0; i < equation.length; i++) {
+    if(equation[i] === 0){
+      if(equation.indexOf("=") === -1 || equation.indexOf("=") > i)
         return T.texts.feedback.zero
     }
   }
 
-  let equalsIndex = equationWithNumbers.indexOf('=')
+  let equalsIndex = equation.indexOf('=')
   if(equalsIndex === -1)
     return ""
 

--- a/src/reducers/validate-equation.js
+++ b/src/reducers/validate-equation.js
@@ -34,7 +34,7 @@ const validateEquation = (equation, state, tileClicked = -1) => {
   }
 
   let equationWithNumbers = simplifyEquationNumbers(equation, isIntArray)
-  let easyFeedback = checkEasyEquations(equationWithNumbers, isIntArray)
+  let easyFeedback = checkEasyEquations(equation, isIntArray)
   if(easyFeedback !== ""){
     return Object.assign({}, state, {
       ...equationOverGameData,


### PR DESCRIPTION
In the real app I noticed that `333*3=` returned a `Too Short` error. It basically thought there was no operator in the equation. This turned out to be because I was passing `equationWithNumbers`, rather than `equation` to `checkEasyEquations`. 

I fixed that and added a couple validations to make sure it didn't happen again. 
