### PR TITLE
Validate Repeat Patterns

### DIFF
--- a/src/reducers/__test__/reducer-game-data.test.js
+++ b/src/reducers/__test__/reducer-game-data.test.js
@@ -171,7 +171,8 @@ let tests = [
     expectedGameData: {
       ...equationOverGameData,
       feedback: "+30",
-      score: 30
+      score: 30,
+      usedPatterns: [15192343187153056000]
     }
   },
   {
@@ -197,6 +198,22 @@ let tests = [
     },
     expectedGameData: {
       equation: [7, "+", 1, "*", 9, "-", 3, "*", 8, "-", 4, "=", "-", 1]
+    }
+  },
+  // Correct, but repeat equation
+  {
+    gameData: {
+      equation: [8, "/", 2, "="],
+      // This used pattern is from `2*4=8`
+      usedPatterns: [160979]
+    },
+    action: {
+      type: 'CLICK_CALCULATOR',
+      itemClicked: 4
+    },
+    expectedGameData: {
+      ...equationOverGameData,
+      feedback: T.texts.feedback.repeat
     }
   }
 ]

--- a/src/reducers/check-used-patterns.js
+++ b/src/reducers/check-used-patterns.js
@@ -9,22 +9,43 @@
 //   Associated prime numbers:    5,  7,  11
 //   Unique ID for this pattern:  5*7*11 = 385
 // The ID for `1+2=3`, `2+1=3` will be the same, so the player will only get points for the first.
+
+import T from 'i18n-react'
+
 const primeNumbers = [3,5,7,11,13,17,19,23,29,31]
+const primeOperators = {
+  plusMinus: 53,
+  multiplyDivide: 61,
+  factor: 103
+}
 
 const checkUsedPatterns = (usedPatterns, equation) => {
 
   var uniqueId = 1
-  equation.map(function(item){
-    if(item.isInteger(item)){
+  for(let item of equation){
+    if(Number.isInteger(item)){
       uniqueId *= primeNumbers[item]
+    }else{
+      if(item === "+" || item === "-"){
+        uniqueId *= primeOperators.plusMinus
+      }else if(item === "*" || item === "/"){
+        uniqueId *= primeOperators.multiplyDivide
+      }else if(item === "^"){
+        uniqueId *= primeOperators.factor
+      }
     }
-  })
-
-  if(usedPatterns.indexOf(uniqueId) > -1){
-    return 0
   }
 
-  return uniqueId
+  if(usedPatterns.indexOf(uniqueId) > -1){
+    return {
+      pattern: usedPatterns,
+      feedback: T.texts.feedback.repeat,
+    }
+  }
+
+  return {
+    pattern: [...usedPatterns, uniqueId]
+  }
 }
 
 export default checkUsedPatterns

--- a/src/reducers/validate-equation.js
+++ b/src/reducers/validate-equation.js
@@ -7,6 +7,7 @@ import checkAdjacentTile from './check-adjacent-tile'
 import checkEasyEquations from './check-easy-equations'
 import checkEquation from './check-equation'
 import addToScore from './add-to-score'
+import checkUsedPatterns from './check-used-patterns'
 
 const validateEquation = (equation, state, tileClicked = -1) => {
 
@@ -50,9 +51,17 @@ const validateEquation = (equation, state, tileClicked = -1) => {
     })
   }else if(equationFeedback === "correct"){
     let newScore = addToScore(state.score, equation)
+    let newUsedPattern = checkUsedPatterns(state.usedPatterns, equation)
+    if(newUsedPattern.pattern === state.usedPatterns){
+      return Object.assign({}, state, {
+        ...equationOverGameData,
+        feedback: newUsedPattern.feedback
+      })
+    }
     return Object.assign({}, state, {
       ...equationOverGameData,
-      ...newScore
+      ...newScore,
+      usedPatterns: newUsedPattern.pattern
     })
   }else{
     return Object.assign({}, state, {

--- a/src/texts.js
+++ b/src/texts.js
@@ -9,6 +9,7 @@ T.setTexts({
   feedback: {
     incorrect: "Incorrect",
     zero: "×",
-    tooShort: "Too short"
+    tooShort: "Too short",
+    repeat: "Repeat"
   }
 })


### PR DESCRIPTION
We need to make sure the player can't just repeat the same patterns. For example, if they
already got `1+2=3`, `2+1=3` is not longer a valid equation. Similarly, if the same equation
appears on the board twice, the player should only be able to get it once.

By assigning each number (0 - 9) and operator a unique prime number (0=3, 1=5), and by multiplying each prime number for each number in the equation, we can we can give each equation a unique
identifier. Ex:
  Equation:                    1 + 2 = 3
  Associated prime numbers:    5, 53,  7,  11
  Unique ID for this pattern:  5_53_7*11 = 20405
The ID for `1+2=3`, `2+1=3` will be the same, so the player will only get points for the first one. 

Fixes #14 
